### PR TITLE
GrantType: Updated AuthorizationCode and RefreshToken classes to have client_id and client_secrete in the request body.

### DIFF
--- a/src/GrantType/AuthorizationCode.php
+++ b/src/GrantType/AuthorizationCode.php
@@ -89,6 +89,14 @@ class AuthorizationCode implements GrantTypeInterface
                 $data['redirect_uri'] = $this->config['redirect_uri'];
             }
 
+            if ($this->config['client_id']) {
+                $data['client_id'] = $this->config['client_id'];
+            }
+
+            if ($this->config['client_secret']) {
+                $data['client_secret'] = $this->config['client_secret'];
+            }
+
             return \GuzzleHttp\Psr7\stream_for(http_build_query($data, '', '&'));
         }
 
@@ -104,6 +112,14 @@ class AuthorizationCode implements GrantTypeInterface
 
         if ($this->config['redirect_uri']) {
             $postBody->setField('redirect_uri', $this->config['redirect_uri']);
+        }
+
+        if ($this->config['client_id']) {
+            $postBody->setField('redirect_uri', $this->config['client_id']);
+        }
+
+        if ($this->config['client_secret']) {
+            $postBody->setField('client_secret', $this->config['client_secret']);
         }
 
         return $postBody;

--- a/src/GrantType/RefreshToken.php
+++ b/src/GrantType/RefreshToken.php
@@ -86,6 +86,14 @@ class RefreshToken implements GrantTypeInterface
                 $data['scope'] = $this->config['scope'];
             }
 
+            if ($this->config['client_id']) {
+                $data['client_id'] = $this->config['client_id'];
+            }
+
+            if ($this->config['client_secret']) {
+                $data['client_secret'] = $this->config['client_secret'];
+            }
+
             return \GuzzleHttp\Psr7\stream_for(http_build_query($data, '', '&'));
         }
 
@@ -99,6 +107,14 @@ class RefreshToken implements GrantTypeInterface
 
         if ($this->config['scope']) {
             $postBody->setField('scope', $this->config['scope']);
+        }
+
+        if ($this->config['client_id']) {
+            $postBody->setField('redirect_uri', $this->config['client_id']);
+        }
+
+        if ($this->config['client_secret']) {
+            $postBody->setField('client_secret', $this->config['client_secret']);
         }
 
         return $postBody;


### PR DESCRIPTION
When I was implementing Oauth 3 legged authentication, I got "Missing required fields: clientId, clientSecret" error. The following is actual from error log,
`Uncaught PHP Exception kamermans\OAuth2\Exception\AccessTokenRequestException: "Unable to request a new access token" at /app/vendor/kamermans/guzzle-oauth2-subscriber/src/OAuth2Handler.php line 258 {"exception":"[object] (kamermans\\OAuth2\\Exception\\AccessTokenRequestException(code: 0): Unable to request a new access token at /app/vendor/kamermans/guzzle-oauth2-subscriber/src/OAuth2Handler.php:258, GuzzleHttp\\Exception\\ClientException(code: 403): Client error: 'POST https://driftapi.com/oauth2/token' resulted in a '403 Forbidden' response:\n{\"error\":{\"type\":\"authentication_error\",\"message\":\"Missing required fields: clientId, clientSecret\"}}\n at /app/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:113)"} []`

After adding the following block to both classes, it worked as expected.
```
           if ($this->config['client_id']) {
                $data['client_id'] = $this->config['client_id'];
            }

            if ($this->config['client_secret']) {
                $data['client_secret'] = $this->config['client_secret'];
            }
```