### PR TITLE
Added support for Guzzle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
+    - 7.4
 
 install:
     - cd guzzle_environments/${GUZZLE_VERSION}
@@ -22,19 +23,30 @@ env:
     - GUZZLE_VERSION=4
     - GUZZLE_VERSION=5
     - GUZZLE_VERSION=6
+    - GUZZLE_VERSION=7
 
 matrix:
     exclude:
         - php: 5.4
           env: GUZZLE_VERSION=6
+        - php: 5.4
+          env: GUZZLE_VERSION=7
+        - php: 5.5
+          env: GUZZLE_VERSION=7
+        - php: 5.6
+          env: GUZZLE_VERSION=7
         - php: 7.0
           env: GUZZLE_VERSION=4
         - php: 7.0
           env: GUZZLE_VERSION=5
+        - php: 7.0
+          env: GUZZLE_VERSION=7
         - php: 7.1
           env: GUZZLE_VERSION=4
         - php: 7.1
           env: GUZZLE_VERSION=5
+        - php: 7.1
+          env: GUZZLE_VERSION=7
         - php: 7.2
           env: GUZZLE_VERSION=4
         - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": ">=4.0"
+        "guzzlehttp/guzzle": "~4.0|~5.0|~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {

--- a/guzzle_environments/7/composer.json
+++ b/guzzle_environments/7/composer.json
@@ -1,0 +1,27 @@
+{
+    "name": "kamermans/unit-tests",
+    "authors": [
+        {
+            "name": "Steve Kamerman",
+            "email": "stevekamerman@gmail.com"
+        }
+    ],
+    "require-dev": {
+        "guzzlehttp/guzzle": "~7",
+        "phpunit/phpunit": ">=4 <8",
+        "doctrine/cache": "~1.5",
+        "psr/simple-cache": "^1.0",
+        "symfony/cache": "^3.4",
+        "illuminate/cache": "^5.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "kamermans\\OAuth2\\": "../../src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "kamermans\\OAuth2\\Tests\\": "../../tests"
+        }
+    }
+}

--- a/guzzle_environments/7/phpunit.xml.dist
+++ b/guzzle_environments/7/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/autoload.php"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         colors="true">
+    <testsuites>
+        <testsuite name="All Tests">
+            <directory>../../tests</directory>
+            <exclude>../../tests/OAuth2SubscriberTest.php</exclude>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix="Test.php">.</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Signer/AccessToken/QueryString.php
+++ b/src/Signer/AccessToken/QueryString.php
@@ -15,7 +15,7 @@ class QueryString implements SignerInterface
 
     public function sign($request, $accessToken)
     {
-        if (Helper::guzzleIs('~', 6)) {
+        if (Helper::guzzleIs('>=', 6)) {
             $uri = \GuzzleHttp\Psr7\Uri::withQueryValue(
                     $request->getUri(),
                     $this->fieldName,

--- a/src/Signer/ClientCredentials/BasicAuth.php
+++ b/src/Signer/ClientCredentials/BasicAuth.php
@@ -8,7 +8,7 @@ class BasicAuth implements SignerInterface
 {
     public function sign($request, $clientId, $clientSecret)
     {
-        if (Helper::guzzleIs('~', 6)) {
+        if (Helper::guzzleIs('>=', 6)) {
             return $request->withHeader('Authorization', 'Basic ' .  base64_encode($clientId . ':' . $clientSecret));
         }
 

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -9,7 +9,7 @@ class Helper
     public static function guzzleIs($operator, $version, $guzzle_version=null)
     {
         if ($guzzle_version === null) {
-            $guzzle_version = G::VERSION;
+            $guzzle_version = (defined('GuzzleHttp\ClientInterface::VERSION')) ? G::VERSION : G::MAJOR_VERSION;
         }
 
         // version_compare considers 5.1.0 > 5.1, but I don't


### PR DESCRIPTION
This is to add support for Guzzle 7. I checked the upgrade notes and the version constant was the only thing that needed changing. On top of some minor edit for the version checks. I also edited the composer.json with rules so that upcoming versions of Guzzle that might have backwards braking changes are not updated automatically.