### PR TITLE
Added support for `audience` parameter

### DIFF
--- a/src/GrantType/ClientCredentials.php
+++ b/src/GrantType/ClientCredentials.php
@@ -86,6 +86,10 @@ class ClientCredentials implements GrantTypeInterface
                 $data['scope'] = $this->config['scope'];
             }
 
+            if (!empty($this->config['audience'])) {
+                $data['audience'] = $this->config['audience'];
+            }
+
             return \GuzzleHttp\Psr7\stream_for(http_build_query($data, '', '&'));
         }
 
@@ -96,6 +100,10 @@ class ClientCredentials implements GrantTypeInterface
 
         if ($this->config['scope']) {
             $postBody->setField('scope', $this->config['scope']);
+        }
+
+        if (!empty($this->config['audience'])) {
+            $postBody->setField('audience', $this->config['audience']);
         }
 
         return $postBody;


### PR DESCRIPTION
… in POST body when receiving a token.

Please refer to https://tools.ietf.org/id/draft-tschofenig-oauth-audience-00.html