### PR TITLE
bugfix: exclude test files from package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Path-based git attributes
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+# Ignore all test and documentation with "export-ignore".
+/.gitattributes      export-ignore
+/.gitignore          export-ignore
+/.php_cs             export-ignore
+/.travis.yml         export-ignore
+/examples            export-ignore
+/guzzle_environments export-ignore
+/tests               export-ignore


### PR DESCRIPTION
I find out, that your test files brokes PhpStorm code completion.
So it`s good to exclude optional files, which is dont need to be archived in package files.

Look this link: 
https://youtrack.jetbrains.com/issue/WI-61511

You have error in file:
https://github.com/kamermans/guzzle-oauth2-subscriber/blob/master/tests/PHPUnitNamespaceShim.php

![image](https://user-images.githubusercontent.com/196970/128603529-53620211-169d-4e82-9864-22ca51500e76.png)
