### PR TITLE
Move Guzzle from required to suggested

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,10 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~4.0|~5.0|~6.0|~7.0"
+        "php": ">=5.4.0"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "Guzzle ~4.0|~5.0|~6.0|~7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have a situation (PrestaShop CMS) where guzzle is already loaded by the CMS. I want to use your library in my PrestaShop module but with the guzzle already installed by the CMS.
Generally, out of PrestaShop, I think that is good to move guzzle to the suggested packages so all users can use your library alone, without required external packages references.