### PR TITLE
Fix PHP 8.1 deprecation notice

### DIFF
--- a/src/Utils/Collection.php
+++ b/src/Utils/Collection.php
@@ -28,6 +28,8 @@ class Collection implements
         return new \ArrayIterator($this->data);
     }
 
+
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;


### PR DESCRIPTION
PHP 8.1 throws a deprecation error:

```
Deprecated: Return type of kamermans\OAuth2\Utils\Collection::offsetGet($offset) should either be compatible
with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used
to temporarily suppress the notice in /vendor/kamermans/guzzle-oauth2-subscriber/src/Utils/Collection.php on
line 31
```

Adding this comment wil fix the deprecation error for now: https://php.watch/versions/8.1/ReturnTypeWillChange