### PR TITLE
fix: no need to delete the token, just overwrite it

### DIFF
--- a/src/OAuth2Handler.php
+++ b/src/OAuth2Handler.php
@@ -207,7 +207,6 @@ class OAuth2Handler
 
         // If token is not set or expired then try to acquire a new one...
         if ($this->rawToken === null || $this->rawToken->isExpired()) {
-            $this->tokenPersistence->deleteToken();
 
             // Hydrate `rawToken` with a new access token
             $this->requestNewAccessToken();


### PR DESCRIPTION
We don't need to delete the token from the persistence layer, it will be overwritten if it's successfully obtained.
Fixes: #36
