### PR TITLE
method getRawData() of grant types not interface compliant and can lead to TypeError

### DIFF
--- a/src/GrantType/AuthorizationCode.php
+++ b/src/GrantType/AuthorizationCode.php
@@ -66,8 +66,9 @@ class AuthorizationCode implements GrantTypeInterface
         );
 
         $response = $this->client->send($request);
+        $rawData = json_decode($response->getBody(), true);
 
-        return (array) json_decode($response->getBody(), true);
+        return is_array($rawData) ? $rawData : [];
     }
 
     /**

--- a/src/GrantType/ClientCredentials.php
+++ b/src/GrantType/ClientCredentials.php
@@ -68,8 +68,9 @@ class ClientCredentials implements GrantTypeInterface
         );
 
         $response = $this->client->send($request);
+        $rawData = json_decode($response->getBody(), true);
 
-        return (array) json_decode($response->getBody(), true);
+        return is_array($rawData) ? $rawData : [];
     }
 
     /**

--- a/src/GrantType/PasswordCredentials.php
+++ b/src/GrantType/PasswordCredentials.php
@@ -66,8 +66,9 @@ class PasswordCredentials implements GrantTypeInterface
         );
 
         $response = $this->client->send($request);
+        $rawData = json_decode($response->getBody(), true);
 
-        return (array) json_decode($response->getBody(), true);
+        return is_array($rawData) ? $rawData : [];
     }
 
     /**

--- a/src/GrantType/RefreshToken.php
+++ b/src/GrantType/RefreshToken.php
@@ -65,8 +65,9 @@ class RefreshToken implements GrantTypeInterface
         );
 
         $response = $this->client->send($request);
+        $rawData = json_decode($response->getBody(), true);
 
-        return (array) json_decode($response->getBody(), true);
+        return is_array($rawData) ? $rawData : [];
     }
 
     /**


### PR DESCRIPTION
Interface states `GrantTypeInterface::getRawData(): array` 
https://github.com/kamermans/guzzle-oauth2-subscriber/blob/b2dc192f1ce9390d3c0e399ad0610fa1fddc17ea/src/GrantType/GrantTypeInterface.php#L15-L17

but every grant type implementation ends with:
```
    // (...)
    return json_decode($response->getBody(), true);  // array|null|false|true`
}
```

It leads to TypeError if auth endpoint return empty response on bad credential (my case):

```
Uncaught TypeError: Argument 1 passed to kamermans\OAuth2\Token\RawTokenFactory::__invoke() must be of the type array, null given in
/var/www/html/wp-content/plugins/xtm-wpml-connector/vendor/kamermans/guzzle-oauth2-subscriber/src/Token/RawTokenFactory.php:7
```