### PR TITLE
feat: Guzzle Promises 2.0.0

### DIFF
--- a/src/OAuth2Middleware.php
+++ b/src/OAuth2Middleware.php
@@ -83,6 +83,11 @@ class OAuth2Middleware extends OAuth2Handler
     private function onRejected(RequestInterface $request, array $options, $handler)
     {
         return function ($reason) use ($request, $options) {
+            if (class_exists('\GuzzleHttp\Promise\Create')) {
+                return \GuzzleHttp\Promise\Create::rejectionFor($reason);
+            }
+
+            // As of Guzzle Promises 2.0.0, the rejection_for function is deprecated and replaced with Create::rejectionFor
             return \GuzzleHttp\Promise\rejection_for($reason);
         };
     }


### PR DESCRIPTION
This PR adds support for Guzzle Promises 2.0.0 which can be used with Guzzle 7.7.0

Fixes: #53
