### PR TITLE
The restoreToken function return type can be null

### DIFF
--- a/src/Persistence/TokenPersistenceInterface.php
+++ b/src/Persistence/TokenPersistenceInterface.php
@@ -11,7 +11,7 @@ interface TokenPersistenceInterface
      *
      * @param TokenInterface $token
      *
-     * @return TokenInterface Restored token
+     * @return ?TokenInterface Restored token
      */
     public function restoreToken(TokenInterface $token);
 


### PR DESCRIPTION
See the issue : https://github.com/kamermans/guzzle-oauth2-subscriber/issues/56 .