### PR TITLE
Hide user deprecated warnings on return types #55

### DIFF
--- a/src/Utils/Collection.php
+++ b/src/Utils/Collection.php
@@ -22,44 +22,37 @@ class Collection implements
         $this->data = $data;
     }
 
-    #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->data);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->data[$offset]) ? $this->data[$offset] : null;
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->data[$offset] = $value;
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
     }
-        
-    #[\ReturnTypeWillChange]
-    public function toArray()
+
+    public function toArray(): array
     {
         return $this->data;
     }
 
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }


### PR DESCRIPTION
Fixes [PHP 8.1 show user deprecated warnings on return types #55
](https://github.com/kamermans/guzzle-oauth2-subscriber/issues/55)