### PR TITLE
Fix nullable deprecations for PHP 8.4+

### DIFF
--- a/src/OAuth2Handler.php
+++ b/src/OAuth2Handler.php
@@ -77,9 +77,9 @@ class OAuth2Handler
      */
     public function __construct(
                     GrantType\GrantTypeInterface $grantType,
-                    GrantType\GrantTypeInterface $refreshTokenGrantType = null,
-                    Signer\ClientCredentials\SignerInterface $clientCredentialsSigner = null,
-                    Signer\AccessToken\SignerInterface $accessTokenSigner = null
+                    ?GrantType\GrantTypeInterface $refreshTokenGrantType = null,
+                    ?Signer\ClientCredentials\SignerInterface $clientCredentialsSigner = null,
+                    ?Signer\AccessToken\SignerInterface $accessTokenSigner = null
     ) {
         $this->grantType = $grantType;
         $this->refreshTokenGrantType = $refreshTokenGrantType;

--- a/src/Token/RawTokenFactory.php
+++ b/src/Token/RawTokenFactory.php
@@ -4,7 +4,7 @@ namespace kamermans\OAuth2\Token;
 
 class RawTokenFactory
 {
-    public function __invoke(array $data, RawToken $previousToken = null)
+    public function __invoke(array $data, ?RawToken $previousToken = null)
     {
         $accessToken = null;
         $refreshToken = null;


### PR DESCRIPTION
On PHP 8.4, there are a few deprecations:
1. /app/vendor/kamermans/guzzle-oauth2-subscriber/src/OAuth2Handler.php:78
kamermans\OAuth2\OAuth2Handler::__construct(): Implicitly marking parameter $refreshTokenGrantType as nullable is deprecated, the explicit nullable type must be used instead
2. /app/vendor/kamermans/guzzle-oauth2-subscriber/src/OAuth2Handler.php:0
kamermans\OAuth2\OAuth2Handler::__construct(): Implicitly marking parameter $clientCredentialsSigner as nullable is deprecated, the explicit nullable type must be used instead
3. /app/vendor/kamermans/guzzle-oauth2-subscriber/src/OAuth2Handler.php:0
kamermans\OAuth2\OAuth2Handler::__construct(): Implicitly marking parameter $accessTokenSigner as nullable is deprecated, the explicit nullable type must be used instead
4. /app/vendor/kamermans/guzzle-oauth2-subscriber/src/Token/RawTokenFactory.php:7
kamermans\OAuth2\Token\RawTokenFactory::__invoke(): Implicitly marking parameter $previousToken as nullable is deprecated, the explicit nullable type must be used instead